### PR TITLE
Add bu.ac.kr – Baekseok University

### DIFF
--- a/lib/domains/kr/ac/bu.txt
+++ b/lib/domains/kr/ac/bu.txt
@@ -1,0 +1,2 @@
+백석대학교
+Baekseok University


### PR DESCRIPTION
• Official site: https://www.bu.ac.kr/web/index.do
• IT 계열 장기 과정 안내: https://www.bu.ac.kr/web/3788/subview.do